### PR TITLE
(bug fix) now ForecastWeatherData class parses well the datetime of a forescast

### DIFF
--- a/lib/src/main/java/org/bitpipeline/lib/owm/ForecastWeatherData.java
+++ b/lib/src/main/java/org/bitpipeline/lib/owm/ForecastWeatherData.java
@@ -20,7 +20,7 @@ import org.json.JSONObject;
 /**
  * @author mtavares */
 public class ForecastWeatherData extends LocalizedWeatherData {
-	static private final String JSON_CALC_DT = "calc_dt";
+	static private final String DATETIME_KEY_NAME = "dt";
 
 	private long calcDateTime = Long.MIN_VALUE;
 	
@@ -29,7 +29,7 @@ public class ForecastWeatherData extends LocalizedWeatherData {
 	 * @throws JSONException */
 	public ForecastWeatherData (JSONObject json) {
 		super (json);
-		this.calcDateTime = json.optLong (ForecastWeatherData.JSON_CALC_DT, Long.MIN_VALUE);
+		this.calcDateTime = json.optLong (ForecastWeatherData.DATETIME_KEY_NAME, Long.MIN_VALUE);
 	}
 
 	public long getCalcDateTime () {

--- a/lib/src/test/java/org/bitpipeline/lib/owm/ForecastWeatherDataTest.java
+++ b/lib/src/test/java/org/bitpipeline/lib/owm/ForecastWeatherDataTest.java
@@ -1,0 +1,49 @@
+package org.bitpipeline.lib.owm;
+
+import static org.junit.Assert.*;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link ForecastWeatherData}
+ * 
+ * @author cs4r
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ForecastWeatherDataTest {
+
+	private static final String DATETIME_KEY_NAME = "dt";
+	private static final long DESIRED_DATETIME = 123456;
+
+	@Mock
+	private JSONObject jsonObject;
+
+	@Test
+	public void testGetCalcDateTimeWhenDateTimeIsPresentReturns123456()
+			throws JSONException {
+		when(jsonObject.optLong(DATETIME_KEY_NAME, Long.MIN_VALUE)).thenReturn(
+				DESIRED_DATETIME);
+		assertEquals(DESIRED_DATETIME, getDateTimeFromForecastWeatherData());
+	}
+
+	@Test
+	public void testGetCalcDateTimeWhenDateTimeIsNotPresentReturnsLongMinValue() {
+		when(jsonObject.optLong(DATETIME_KEY_NAME, Long.MIN_VALUE)).thenReturn(
+				Long.MIN_VALUE);
+		assertEquals(Long.MIN_VALUE, getDateTimeFromForecastWeatherData());
+	}
+
+	private long getDateTimeFromForecastWeatherData() {
+		return new ForecastWeatherData(jsonObject).getCalcDateTime();
+	}
+
+}


### PR DESCRIPTION
 now ForecastWeatherData class parses well the datetime of a forescast -> DATETIME_KEY_NAME has changed is value to "dt", besides it was added a regression test